### PR TITLE
Add MacOS build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 build
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This is Electron wrapper for [Fugo Web Player](https://player.fugo.ai) ([source](git@github.com:OutOfAxis/pixelart-cms-web-player.git))
 
 ## Development
+
 ```
 npm start
 ```
@@ -10,7 +11,26 @@ npm start
 Also uncomment `mainWindow.webContents.openDevTools()` to see the dev tools.
 
 ## Distrubition
+
+### Windows
+
 Creating an executable installer:
+
 ```
 npm run dist
 ```
+
+### Mac
+
+```
+npm run dist-w
+```
+
+Create .env file in the root with
+
+```
+APPLEID=atn@marsel.name
+APPLEIDPASS=
+```
+
+Get the [App Specific password](https://support.apple.com/en-us/102654) for APPLEIDPASS variable.

--- a/mac-code-sign/entitlements.mac.plist
+++ b/mac-code-sign/entitlements.mac.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>

--- a/mac-code-sign/notarize.js
+++ b/mac-code-sign/notarize.js
@@ -1,0 +1,18 @@
+require('dotenv').config()
+const { notarize } = require('electron-notarize')
+
+exports.default = async function notarizing(context) {
+  const { electronPlatformName, appOutDir } = context
+  if (electronPlatformName !== 'darwin') {
+    return
+  }
+
+  const appName = context.packager.appInfo.productFilename
+
+  return await notarize({
+    appBundleId: 'ai.fugo.player',
+    appPath: `${appOutDir}/${appName}.app`,
+    appleId: process.env.APPLEID,
+    appleIdPassword: process.env.APPLEIDPASS,
+  })
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "fugo-cms-windows-player",
+  "name": "fugo-player",
   "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "fugo-cms-windows-player",
+      "name": "fugo-player",
       "version": "1.16.0",
       "dependencies": {
         "copyfiles": "^2.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fugo-player",
       "version": "1.16.0",
       "dependencies": {
+        "@nut-tree/nut-js": "^3.1.2",
         "copyfiles": "^2.4.1",
         "electron-log": "^4.4.8",
         "electron-notarize": "^1.2.2",
@@ -19,6 +20,22 @@
         "electron": "^24.0.0",
         "electron-builder": "^23.6.0"
       }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.0.tgz",
+      "integrity": "sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@develar/schema-utils": {
       "version": "2.6.5",
@@ -112,6 +129,438 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@jimp/bmp": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/bmp/-/bmp-0.16.13.tgz",
+      "integrity": "sha512-9edAxu7N2FX7vzkdl5Jo1BbACfycUtBQX+XBMcHA2bk62P8R0otgkHg798frgAk/WxQIzwxqOH6wMiCwrlAzdQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "bmp-js": "^0.1.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/core": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/core/-/core-0.16.13.tgz",
+      "integrity": "sha512-qXpA1tzTnlkTku9yqtuRtS/wVntvE6f3m3GNxdTdtmc+O+Wcg9Xo2ABPMh7Nc0AHbMKzwvwgB2JnjZmlmJEObg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "any-base": "^1.1.0",
+        "buffer": "^5.2.0",
+        "exif-parser": "^0.1.12",
+        "file-type": "^16.5.4",
+        "load-bmfont": "^1.3.1",
+        "mkdirp": "^0.5.1",
+        "phin": "^2.9.1",
+        "pixelmatch": "^4.0.2",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "node_modules/@jimp/core/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/@jimp/custom": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/custom/-/custom-0.16.13.tgz",
+      "integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/core": "^0.16.13"
+      }
+    },
+    "node_modules/@jimp/gif": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/gif/-/gif-0.16.13.tgz",
+      "integrity": "sha512-yFAMZGv3o+YcjXilMWWwS/bv1iSqykFahFMSO169uVMtfQVfa90kt4/kDwrXNR6Q9i6VHpFiGZMlF2UnHClBvg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "gifwrap": "^0.9.2",
+        "omggif": "^1.0.9"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/jpeg": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/jpeg/-/jpeg-0.16.13.tgz",
+      "integrity": "sha512-BJHlDxzTlCqP2ThqP8J0eDrbBfod7npWCbJAcfkKqdQuFk0zBPaZ6KKaQKyKxmWJ87Z6ohANZoMKEbtvrwz1AA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "jpeg-js": "^0.4.2"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-blit": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blit/-/plugin-blit-0.16.13.tgz",
+      "integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-blur": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-blur/-/plugin-blur-0.16.13.tgz",
+      "integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-circle": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-circle/-/plugin-circle-0.16.13.tgz",
+      "integrity": "sha512-RNave7EFgZrb5V5EpdvJGAEHMnDAJuwv05hKscNfIYxf0kR3KhViBTDy+MoTnMlIvaKFULfwIgaZWzyhuINMzA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-color": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-color/-/plugin-color-0.16.13.tgz",
+      "integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "tinycolor2": "^1.4.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-contain": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-contain/-/plugin-contain-0.16.13.tgz",
+      "integrity": "sha512-QayTXw4tXMwU6q6acNTQrTTFTXpNRBe+MgTGMDU0lk+23PjlFCO/9sacflelG8lsp7vNHhAxFeHptDMAksEYzg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5",
+        "@jimp/plugin-scale": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-cover": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-cover/-/plugin-cover-0.16.13.tgz",
+      "integrity": "sha512-BSsP71GTNaqWRcvkbWuIVH+zK7b3TSNebbhDkFK0fVaUTzHuKMS/mgY4hDZIEVt7Rf5FjadAYtsujHN9w0iSYA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-crop": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5",
+        "@jimp/plugin-scale": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-crop": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-crop/-/plugin-crop-0.16.13.tgz",
+      "integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-displace": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-displace/-/plugin-displace-0.16.13.tgz",
+      "integrity": "sha512-qt9WKq8vWrcjySa9DyQ0x/RBMHQeiVjdVSY1SJsMjssPUf0pS74qorcuAkGi89biN3YoGUgPkpqECnAWnYwgGA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-dither": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-dither/-/plugin-dither-0.16.13.tgz",
+      "integrity": "sha512-5/N3yJggbWQTlGZHQYJPmQXEwR52qaXjEzkp1yRBbtdaekXE3BG/suo0fqeoV/csf8ooI78sJzYmIrxNoWVtgQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-fisheye": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-fisheye/-/plugin-fisheye-0.16.13.tgz",
+      "integrity": "sha512-2rZmTdFbT/cF9lEZIkXCYO0TsT114Q27AX5IAo0Sju6jVQbvIk1dFUTnwLDadTo8wkJlFzGqMQ24Cs8cHWOliA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-flip": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-flip/-/plugin-flip-0.16.13.tgz",
+      "integrity": "sha512-EmcgAA74FTc5u7Z+hUO/sRjWwfPPLuOQP5O64x5g4j0T12Bd29IgsYZxoutZo/rb3579+JNa/3wsSEmyVv1EpA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-rotate": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-gaussian": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-gaussian/-/plugin-gaussian-0.16.13.tgz",
+      "integrity": "sha512-A1XKfGQD0iDdIiKqFYi8nZMv4dDVYdxbrmgR7y/CzUHhSYdcmoljLIIsZZM3Iks/Wa353W3vtvkWLuDbQbch1w==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-invert": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-invert/-/plugin-invert-0.16.13.tgz",
+      "integrity": "sha512-xFMrIn7czEZbdbMzZWuaZFnlLGJDVJ82y5vlsKsXRTG2kcxRsMPXvZRWHV57nSs1YFsNqXSbrC8B98n0E32njQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-mask": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-mask/-/plugin-mask-0.16.13.tgz",
+      "integrity": "sha512-wLRYKVBXql2GAYgt6FkTnCfE+q5NomM7Dlh0oIPGAoMBWDyTx0eYutRK6PlUrRK2yMHuroAJCglICTbxqGzowQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-normalize": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-normalize/-/plugin-normalize-0.16.13.tgz",
+      "integrity": "sha512-3tfad0n9soRna4IfW9NzQdQ2Z3ijkmo21DREHbE6CGcMIxOSvfRdSvf1qQPApxjTSo8LTU4MCi/fidx/NZ0GqQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-print": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-print/-/plugin-print-0.16.13.tgz",
+      "integrity": "sha512-0m6i3p01PGRkGAK9r53hDYrkyMq+tlhLOIbsSTmZyh6HLshUKlTB7eXskF5OpVd5ZUHoltlNc6R+ggvKIzxRFw==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "load-bmfont": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-resize": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-resize/-/plugin-resize-0.16.13.tgz",
+      "integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-rotate": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-rotate/-/plugin-rotate-0.16.13.tgz",
+      "integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blit": ">=0.3.5",
+        "@jimp/plugin-crop": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-scale": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-scale/-/plugin-scale-0.16.13.tgz",
+      "integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-shadow": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-shadow/-/plugin-shadow-0.16.13.tgz",
+      "integrity": "sha512-nmu5VSZ9hsB1JchTKhnnCY+paRBnwzSyK5fhkhtQHHoFD5ArBQ/5wU8y6tCr7k/GQhhGq1OrixsECeMjPoc8Zw==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-blur": ">=0.3.5",
+        "@jimp/plugin-resize": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/plugin-threshold": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugin-threshold/-/plugin-threshold-0.16.13.tgz",
+      "integrity": "sha512-+3zArBH0OE3Rhjm4HyAokMsZlIq5gpQec33CncyoSwxtRBM2WAhUVmCUKuBo+Lr/2/4ISoY4BWpHKhMLDix6cA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5",
+        "@jimp/plugin-color": ">=0.8.0",
+        "@jimp/plugin-resize": ">=0.8.0"
+      }
+    },
+    "node_modules/@jimp/plugins": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/plugins/-/plugins-0.16.13.tgz",
+      "integrity": "sha512-CJLdqODEhEVs4MgWCxpWL5l95sCBlkuSLz65cxEm56X5akIsn4LOlwnKoSEZioYcZUBvHhCheH67AyPTudfnQQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/plugin-blit": "^0.16.13",
+        "@jimp/plugin-blur": "^0.16.13",
+        "@jimp/plugin-circle": "^0.16.13",
+        "@jimp/plugin-color": "^0.16.13",
+        "@jimp/plugin-contain": "^0.16.13",
+        "@jimp/plugin-cover": "^0.16.13",
+        "@jimp/plugin-crop": "^0.16.13",
+        "@jimp/plugin-displace": "^0.16.13",
+        "@jimp/plugin-dither": "^0.16.13",
+        "@jimp/plugin-fisheye": "^0.16.13",
+        "@jimp/plugin-flip": "^0.16.13",
+        "@jimp/plugin-gaussian": "^0.16.13",
+        "@jimp/plugin-invert": "^0.16.13",
+        "@jimp/plugin-mask": "^0.16.13",
+        "@jimp/plugin-normalize": "^0.16.13",
+        "@jimp/plugin-print": "^0.16.13",
+        "@jimp/plugin-resize": "^0.16.13",
+        "@jimp/plugin-rotate": "^0.16.13",
+        "@jimp/plugin-scale": "^0.16.13",
+        "@jimp/plugin-shadow": "^0.16.13",
+        "@jimp/plugin-threshold": "^0.16.13",
+        "timm": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/png": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/png/-/png-0.16.13.tgz",
+      "integrity": "sha512-8cGqINvbWJf1G0Her9zbq9I80roEX0A+U45xFby3tDWfzn+Zz8XKDF1Nv9VUwVx0N3zpcG1RPs9hfheG4Cq2kg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/utils": "^0.16.13",
+        "pngjs": "^3.3.3"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/tiff": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/tiff/-/tiff-0.16.13.tgz",
+      "integrity": "sha512-oJY8d9u95SwW00VPHuCNxPap6Q1+E/xM5QThb9Hu+P6EGuu6lIeLaNBMmFZyblwFbwrH+WBOZlvIzDhi4Dm/6Q==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "utif": "^2.0.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/types": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/types/-/types-0.16.13.tgz",
+      "integrity": "sha512-mC0yVNUobFDjoYLg4hoUwzMKgNlxynzwt3cDXzumGvRJ7Kb8qQGOWJQjQFo5OxmGExqzPphkirdbBF88RVLBCg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/bmp": "^0.16.13",
+        "@jimp/gif": "^0.16.13",
+        "@jimp/jpeg": "^0.16.13",
+        "@jimp/png": "^0.16.13",
+        "@jimp/tiff": "^0.16.13",
+        "timm": "^1.6.1"
+      },
+      "peerDependencies": {
+        "@jimp/custom": ">=0.3.5"
+      }
+    },
+    "node_modules/@jimp/utils": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/@jimp/utils/-/utils-0.16.13.tgz",
+      "integrity": "sha512-VyCpkZzFTHXtKgVO35iKN0sYR10psGpV6SkcSeV4oF7eSYlR8Bl6aQLCzVeFjvESF7mxTmIiI3/XrMobVrtxDA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
     "node_modules/@malept/cross-spawn-promise": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
@@ -185,6 +634,127 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/@nut-tree/libnut": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nut-tree/libnut/-/libnut-2.5.2.tgz",
+      "integrity": "sha512-IwlGgalGQjjCrbPq52HTLtsR6MRsGJ6c4GhgHmgwJPD/yBVCzsU5EA2rwDgjKSgK+jiLOpykySDZQ+owhyd1zw==",
+      "dependencies": {
+        "@nut-tree/libnut-darwin": "2.5.2",
+        "@nut-tree/libnut-linux": "2.5.2",
+        "@nut-tree/libnut-win32": "2.5.2"
+      },
+      "engines": {
+        "node": ">=10.15.3"
+      }
+    },
+    "node_modules/@nut-tree/libnut-darwin": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nut-tree/libnut-darwin/-/libnut-darwin-2.5.2.tgz",
+      "integrity": "sha512-OKqCgpBbZj2oNQkLM+mM7TyiLBAQsRyN7Q5UXVKbyXnzcQTU1FZBJ1mLGvdfzzspajznL3Mkl08AQE+xYYbTMw==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "bindings": "1.5.0"
+      },
+      "engines": {
+        "node": ">=10.15.3"
+      },
+      "optionalDependencies": {
+        "@nut-tree/node-mac-permissions": "2.2.1"
+      }
+    },
+    "node_modules/@nut-tree/libnut-linux": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nut-tree/libnut-linux/-/libnut-linux-2.5.2.tgz",
+      "integrity": "sha512-uY6XDuNE8soYRUhV23g6KQN5BRR43MYNLyPnrrQa5Wtfgm6oW9kBRu6JtkWz6Fn6trAWrVAKnbPoTiEgHuGz9w==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "bindings": "1.5.0"
+      },
+      "engines": {
+        "node": ">=10.15.3"
+      },
+      "optionalDependencies": {
+        "@nut-tree/node-mac-permissions": "2.2.1"
+      }
+    },
+    "node_modules/@nut-tree/libnut-win32": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@nut-tree/libnut-win32/-/libnut-win32-2.5.2.tgz",
+      "integrity": "sha512-cnNAQ0pzUMH7hrSjTWRiFfXid3sbSZ78jpv1rA154dlka3wqo6m1OtaX4PLVQK4irZl5REz74iPdHcjeTy9rtg==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "bindings": "1.5.0"
+      },
+      "engines": {
+        "node": ">=10.15.3"
+      },
+      "optionalDependencies": {
+        "@nut-tree/node-mac-permissions": "2.2.1"
+      }
+    },
+    "node_modules/@nut-tree/node-mac-permissions": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@nut-tree/node-mac-permissions/-/node-mac-permissions-2.2.1.tgz",
+      "integrity": "sha512-yoijwCqt2yS9UFTv7THGUwZgy2D2TorN703QpYNOergbTJ6vEmeG379pIZDfBuvf56n24RMzKJVoSqr9WIq/Yw==",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "bindings": "1.5.0",
+        "node-addon-api": "5.0.0"
+      }
+    },
+    "node_modules/@nut-tree/node-mac-permissions/node_modules/node-addon-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
+      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
+      "optional": true
+    },
+    "node_modules/@nut-tree/nut-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@nut-tree/nut-js/-/nut-js-3.1.2.tgz",
+      "integrity": "sha512-hi7DBZz9O/t4goeQu3hKeauQbb0PcBmurScl3/t5L3I1pub3ibV24sft8KNSS3INKnGCj7I3Ma5iNHQ24g+95g==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "os": [
+        "linux",
+        "darwin",
+        "win32"
+      ],
+      "dependencies": {
+        "@nut-tree/libnut": "2.5.2",
+        "clipboardy": "2.3.0",
+        "jimp": "0.16.13",
+        "node-abort-controller": "2.0.0"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -208,6 +778,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
@@ -415,6 +990,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-base": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/any-base/-/any-base-1.1.0.tgz",
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+    },
     "node_modules/app-builder-bin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-4.0.0.tgz",
@@ -508,6 +1088,25 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -593,7 +1192,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -609,6 +1207,14 @@
         }
       ]
     },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "node_modules/bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -623,6 +1229,11 @@
       "dependencies": {
         "bluebird": "^3.5.5"
       }
+    },
+    "node_modules/bmp-js": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bmp-js/-/bmp-js-0.1.0.tgz",
+      "integrity": "sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw=="
     },
     "node_modules/boolean": {
       "version": "3.2.0",
@@ -644,7 +1255,6 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
       "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -659,7 +1269,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -871,6 +1480,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clipboardy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
+      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "dependencies": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cliui": {
@@ -1243,6 +1865,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
     "node_modules/dotenv": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-9.0.2.tgz",
@@ -1574,7 +2201,6 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "dev": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -1615,6 +2241,100 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dependencies": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/execa/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/exif-parser": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/exif-parser/-/exif-parser-0.1.12.tgz",
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -1666,6 +2386,27 @@
       "dependencies": {
         "pend": "~1.2.0"
       }
+    },
+    "node_modules/file-type": {
+      "version": "16.5.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.4.tgz",
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": {
+        "readable-web-to-node-stream": "^3.0.0",
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -1799,6 +2540,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gifwrap": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/gifwrap/-/gifwrap-0.9.4.tgz",
+      "integrity": "sha512-MDMwbhASQuVeD4JKd1fKgNgCRL3fGqMM4WaqpNhWO0JiMOAjbQdumbs4BbBZEy9/M00EHEjKN3HieVhCUlwjeQ==",
+      "dependencies": {
+        "image-q": "^4.0.0",
+        "omggif": "^1.0.10"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -1816,6 +2566,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
       }
     },
     "node_modules/global-agent": {
@@ -2043,7 +2802,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2057,8 +2815,20 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "optional": true
+      ]
+    },
+    "node_modules/image-q": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/image-q/-/image-q-4.0.0.tgz",
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "dependencies": {
+        "@types/node": "16.9.1"
+      }
+    },
+    "node_modules/image-q/node_modules/@types/node": {
+      "version": "16.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.9.1.tgz",
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -2086,10 +2856,48 @@
         "is-ci": "bin.js"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-function": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -2114,8 +2922,7 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jake": {
       "version": "10.8.5",
@@ -2134,6 +2941,23 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/jimp": {
+      "version": "0.16.13",
+      "resolved": "https://registry.npmjs.org/jimp/-/jimp-0.16.13.tgz",
+      "integrity": "sha512-Bxz8q7V4rnCky9A0ktTNGA9SkNFVWRHodddI/DaAWZJzF7sVUlFYKQ60y9JGqrKpi48ECA/TnfMzzc5C70VByA==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "@jimp/custom": "^0.16.13",
+        "@jimp/plugins": "^0.16.13",
+        "@jimp/types": "^0.16.13",
+        "regenerator-runtime": "^0.13.3"
+      }
+    },
+    "node_modules/jpeg-js": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -2199,6 +3023,40 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q=="
+    },
+    "node_modules/load-bmfont": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.1.tgz",
+      "integrity": "sha512-8UyQoYmdRDy81Brz6aLAUhfZLwr5zV0L3taTQ4hju7m6biuwiWiJXjPhBJxbUQJA8PrkvJ/7Enqmwk2sM14soA==",
+      "dependencies": {
+        "buffer-equal": "0.0.1",
+        "mime": "^1.3.4",
+        "parse-bmfont-ascii": "^1.0.3",
+        "parse-bmfont-binary": "^1.0.5",
+        "parse-bmfont-xml": "^1.1.4",
+        "phin": "^2.9.1",
+        "xhr": "^2.0.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/load-bmfont/node_modules/buffer-equal": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/load-bmfont/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -2291,6 +3149,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2306,7 +3172,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -2361,6 +3226,16 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+    },
+    "node_modules/node-abort-controller": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-abort-controller/-/node-abort-controller-2.0.0.tgz",
+      "integrity": "sha512-L8RfEgjBTHAISTuagw51PprVAqNZoG6KSB6LQ6H1bskMVkFs5E71IyjauLBv3XbuomJlguWF/VnRHdJ1gqiAqA=="
+    },
     "node_modules/node-addon-api": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
@@ -2408,6 +3283,25 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "dependencies": {
+        "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -2417,6 +3311,11 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/omggif": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.10.tgz",
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -2435,6 +3334,43 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "node_modules/parse-bmfont-ascii": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
+    },
+    "node_modules/parse-bmfont-binary": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
+    },
+    "node_modules/parse-bmfont-xml": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "dependencies": {
+        "xml-parse-from-string": "^1.0.0",
+        "xml2js": "^0.5.0"
+      }
+    },
+    "node_modules/parse-headers": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -2452,11 +3388,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/peek-readable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.1.0.tgz",
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
+    },
+    "node_modules/phin": {
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/phin/-/phin-2.9.3.tgz",
+      "integrity": "sha512-CzFr90qM24ju5f88quFC/6qohjC144rehe5n6DH900lgXmUe86+xCKc10ev56gRKC4/BkHUoG4uSiQgBiIXwDA==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info."
+    },
+    "node_modules/pixelmatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-4.0.2.tgz",
+      "integrity": "sha512-J8B6xqiO37sU/gkcMglv6h5Jbd9xNER7aHzpfRdNmV4IbQBzBpe4l9XmbG+xPF/znacgu2jfEw+wHffaq/YkXA==",
+      "dependencies": {
+        "pngjs": "^3.0.0"
+      },
+      "bin": {
+        "pixelmatch": "bin/pixelmatch"
+      }
     },
     "node_modules/plist": {
       "version": "3.0.6",
@@ -2469,6 +3434,22 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2489,7 +3470,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "dev": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -2542,6 +3522,66 @@
         "isarray": "0.0.1",
         "string_decoder": "~0.10.x"
       }
+    },
+    "node_modules/readable-web-to-node-stream": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
+      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/readable-web-to-node-stream/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -2689,6 +3729,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+    },
     "node_modules/simple-update-notifier": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-1.1.0.tgz",
@@ -2798,6 +3843,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strtok3": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.3.0.tgz",
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/sumchecker": {
@@ -2922,6 +3991,16 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/timm": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/timm/-/timm-1.7.1.tgz",
+      "integrity": "sha512-IjZc9KIotudix8bMaBW6QvMuq64BrJWFs1+4V0lXwWGQZwH+LnX87doAYhem4caOEusRP9/g6jVDQmZ8XOk1nw=="
+    },
+    "node_modules/tinycolor2": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
@@ -2941,6 +4020,22 @@
       "dev": true,
       "dependencies": {
         "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.2.1.tgz",
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/tr46": {
@@ -3028,6 +4123,14 @@
       "integrity": "sha512-4+wkEYLBbWxqTahEsWrhxepcoVOJ+1z5PGIjPZxRkytcdSUaNjIjBM7Xn8E+pdSuV7SzvWovBFA54FO0JSoqhA==",
       "dev": true
     },
+    "node_modules/utif": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/utif/-/utif-2.0.1.tgz",
+      "integrity": "sha512-Z/S1fNKCicQTf375lIP9G8Sa1H/phcysstNrrSdZKj1f9g58J4NMgb5IgiEZN9/nLMPDwF0W7hdOe9Qq2IYoLg==",
+      "dependencies": {
+        "pako": "^1.0.5"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3104,6 +4207,42 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/xhr": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
+      "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
+      "dependencies": {
+        "global": "~4.4.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
+      }
+    },
+    "node_modules/xml-parse-from-string": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "fugo-cms-windows-player",
-  "version": "1.14.0",
+  "version": "1.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fugo-cms-windows-player",
-      "version": "1.14.0",
+      "version": "1.16.0",
       "dependencies": {
         "copyfiles": "^2.4.1",
         "electron-log": "^4.4.8",
+        "electron-notarize": "^1.2.2",
         "electron-updater": "^5.3.0",
         "node-fetch": "2.6.9",
         "typescript": "^5.0.4"
@@ -579,7 +580,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -1357,6 +1357,52 @@
       "version": "4.4.8",
       "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-4.4.8.tgz",
       "integrity": "sha512-QQ4GvrXO+HkgqqEOYbi+DHL7hj5JM+nHi/j+qrN9zeeXVKy8ZABgbu4CnG+BBqDZ2+tbeq9tUC4DZfIWFU5AZA=="
+    },
+    "node_modules/electron-notarize": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/electron-notarize/-/electron-notarize-1.2.2.tgz",
+      "integrity": "sha512-ZStVWYcWI7g87/PgjPJSIIhwQXOaw4/XeXU+pWqMMktSLHaGMLHdyPPN7Cmao7+Cr7fYufA16npdtMndYciHNw==",
+      "deprecated": "Please use @electron/notarize moving forward.  There is no API change, just a package name change",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/electron-osx-sign": {
       "version": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fugo-player",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fugo-player",
-      "version": "1.16.0",
+      "version": "1.17.0",
       "dependencies": {
         "@nut-tree/nut-js": "^3.1.2",
         "copyfiles": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "semi": false
   },
   "dependencies": {
+    "@nut-tree/nut-js": "^3.1.2",
     "copyfiles": "^2.4.1",
     "electron-log": "^4.4.8",
     "electron-notarize": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "fugo-cms-windows-player",
+  "name": "fugo-player",
   "version": "1.16.0",
-  "description": "Fugo CMS Windows Player",
+  "description": "Fugo Player",
   "main": "build/main.js",
   "scripts": {
     "build": "tsc && npm run copyassets",
@@ -9,7 +9,7 @@
     "start": "tsc && electron ./build/main.js",
     "copyassets": "copyfiles -u 1 src/assets/* build",
     "dist": "npm run build && electron-builder -w",
-    "dist-m": "electron-builder",
+    "dist-m": "npm run build && copyfiles -f src/assets/* build  && electron-builder -m",
     "buildpreload": "tsc ./preload.ts"
   },
   "repository": "https://github.com/OutOfAxis/fugo-electron",
@@ -27,7 +27,7 @@
     "files": [
       "build/**/*"
     ],
-    "appId": "ai.fugo.windowplayer",
+    "appId": "ai.fugo.player",
     "mac": {
       "type": "distribution",
       "target": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fugo-player",
-  "version": "1.16.0",
+  "version": "1.17.0",
   "description": "Fugo Player",
   "main": "build/main.js",
   "scripts": {
@@ -32,7 +32,7 @@
       "type": "distribution",
       "target": [
         {
-          "target": "dmg",
+          "target": "default",
           "arch": "universal"
         }
       ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "start": "tsc && electron ./build/main.js",
     "copyassets": "copyfiles -u 1 src/assets/* build",
     "dist": "npm run build && electron-builder -w",
+    "dist-m": "electron-builder",
     "buildpreload": "tsc ./preload.ts"
   },
   "repository": "https://github.com/OutOfAxis/fugo-electron",
@@ -22,12 +23,35 @@
     "electron-builder": "^23.6.0"
   },
   "build": {
+    "afterSign": "mac-code-sign/notarize.js",
     "files": [
       "build/**/*"
     ],
     "appId": "ai.fugo.windowplayer",
     "mac": {
-      "category": "public.app-category.business"
+      "type": "distribution",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": "universal"
+        }
+      ],
+      "artifactName": "${productName}-${version}-${os}.${ext}",
+      "category": "public.app-category.business",
+      "hardenedRuntime": true,
+      "gatekeeperAssess": false,
+      "entitlements": "mac-code-sign/entitlements.mac.plist",
+      "entitlementsInherit": "mac-code-sign/entitlements.mac.plist"
+    },
+    "dmg": {
+      "sign": false
+    },
+    "mas": {
+      "hardenedRuntime": false,
+      "type": "distribution",
+      "category": "public.app-category.utilities",
+      "entitlements": "build/entitlements.mas.plist",
+      "entitlementsInherit": "build/entitlements.mas.inherit.plist"
     },
     "appx": {
       "publisher": "E=zuka@fugo.ai, CN=outofaxis limited, O=outofaxis limited, STREET=\"Gullane, Grove End Lane\", L=Esher, S=Surrey, C=GB, OID.1.3.6.1.4.1.311.60.2.1.3=GB, SERIALNUMBER=08603300, OID.2.5.4.15=Private Organization",
@@ -59,6 +83,7 @@
   "dependencies": {
     "copyfiles": "^2.4.1",
     "electron-log": "^4.4.8",
+    "electron-notarize": "^1.2.2",
     "electron-updater": "^5.3.0",
     "node-fetch": "2.6.9",
     "typescript": "^5.0.4"

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import {
 } from 'electron'
 import { Settings } from './settings'
 
+const { mouse, Point } = require('@nut-tree/nut-js')
 const { app, BrowserWindow, Tray, Menu, ipcMain } = require('electron')
 const path = require('path')
 const { autoUpdater } = require('electron-updater')
@@ -122,6 +123,7 @@ async function createWindow() {
     })
     autoUpdater.checkForUpdatesAndNotify()
   }, 1000 * 60 * 60 * 1)
+  await mouse.setPosition(new Point(500, 500))
 }
 
 function goFullscreen() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ async function createWindow() {
     ])
   )
 
-  const webPlayerURL = `https://player.fugo.ai/?platform=${process.platform}`
+  const webPlayerURL = `https://player.fugo.ai/`
   mainWindow.loadURL(webPlayerURL)
   mainWindow.setAlwaysOnTop(isKiosk, 'screen-saver')
   mainWindow.show()

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,9 @@
-import { IpcMainInvokeEvent, NativeImage, powerSaveBlocker } from 'electron'
+import {
+  IpcMainInvokeEvent,
+  NativeImage,
+  nativeImage,
+  powerSaveBlocker,
+} from 'electron'
 import { Settings } from './settings'
 
 const { app, BrowserWindow, Tray, Menu, ipcMain } = require('electron')
@@ -43,7 +48,9 @@ async function createWindow() {
   })
 
   const iconPath = path.join(__dirname, 'assets/icon.png')
-  tr = new Tray(iconPath)
+  const iconImage = nativeImage.createFromPath(iconPath)
+  tr = new Tray(iconImage.resize({ width: 16, height: 16 }))
+
   tr.addListener('click', () => {
     show()
   })
@@ -62,7 +69,7 @@ async function createWindow() {
     ])
   )
 
-  const webPlayerURL = 'https://player.fugo.ai'
+  const webPlayerURL = 'https://player.fugo.ai/?platform=mac'
   mainWindow.loadURL(webPlayerURL)
   mainWindow.setAlwaysOnTop(isKiosk, 'screen-saver')
   mainWindow.show()
@@ -75,7 +82,7 @@ async function createWindow() {
   // mainWindow.webContents.openDevTools()
 
   mainWindow.on('maximize', () => {
-    goFullscreen();
+    goFullscreen()
   })
 
   mainWindow.on('closed', function () {
@@ -282,7 +289,7 @@ function reloadWebPlayer(appGuarded: typeof app) {
 function handleDoScreenshot(event: any, url: string) {
   const window =
     displayingFullscreenWebsiteId &&
-      displayWebsites[displayingFullscreenWebsiteId]
+    displayWebsites[displayingFullscreenWebsiteId]
       ? displayWebsites[displayingFullscreenWebsiteId]
       : mainWindow
   window.webContents.capturePage().then((image: NativeImage) => {
@@ -299,7 +306,9 @@ function handleGetVersion() {
 
 async function handleSetKiosk(event: IpcMainInvokeEvent, isEnabled: boolean) {
   const currentSettingsValue = (await Settings.get()).isKiosk
-  console.log(`Setting kiosk to ${isEnabled}. Settings state: ${currentSettingsValue}. App state: ${mainWindow.isKiosk()}`)
+  console.log(
+    `Setting kiosk to ${isEnabled}. Settings state: ${currentSettingsValue}. App state: ${mainWindow.isKiosk()}`
+  )
   await Settings.set({ isKiosk: isEnabled })
   // avoid setting it to the same value because it breaks fullscreen mode
   // PlayerJS sets it to false on startup if player was unpaired before

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import {
   NativeImage,
   nativeImage,
   powerSaveBlocker,
+  screen,
 } from 'electron'
 import { Settings } from './settings'
 
@@ -123,7 +124,7 @@ async function createWindow() {
     })
     autoUpdater.checkForUpdatesAndNotify()
   }, 1000 * 60 * 60 * 1)
-  await mouse.setPosition(new Point(500, 500))
+  await mouse.setPosition(new Point(0, screen.getPrimaryDisplay().size.height))
 }
 
 function goFullscreen() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ async function createWindow() {
     ])
   )
 
-  const webPlayerURL = 'https://player.fugo.ai/?platform=mac'
+  const webPlayerURL = `https://player.fugo.ai/?platform=${process.platform}`
   mainWindow.loadURL(webPlayerURL)
   mainWindow.setAlwaysOnTop(isKiosk, 'screen-saver')
   mainWindow.show()

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -62,6 +62,10 @@ let fugoElectronBridgeInstance: FugoElectronBridge = {
   destroyWebsiteFullscreen() {
     ipcRenderer.invoke('destroyWebsiteFullscreen')
   },
+
+  getSystemMemoryInfo() {
+    return process.getSystemMemoryInfo()
+  },
 }
 
 contextBridge.exposeInMainWorld(
@@ -96,4 +100,5 @@ interface DisplayWebsite {
   destroyWebsiteFullscreen: () => void
   destroyWebsite: (id: string) => void
   setKiosk(isEnabled: boolean): void
+  getSystemMemoryInfo(): { total: number; free: number }
 }

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -66,6 +66,10 @@ let fugoElectronBridgeInstance: FugoElectronBridge = {
   getSystemMemoryInfo() {
     return process.getSystemMemoryInfo()
   },
+
+  getPlatform() {
+    return process.platform
+  },
 }
 
 contextBridge.exposeInMainWorld(
@@ -101,4 +105,5 @@ interface DisplayWebsite {
   destroyWebsite: (id: string) => void
   setKiosk(isEnabled: boolean): void
   getSystemMemoryInfo(): { total: number; free: number }
+  getPlatform(): NodeJS.Platform
 }


### PR DESCRIPTION
This patch adds everything for us to build Mac app
- notorized .DMG executables for installing the app
- .zip target for auto-update to work
- various icons 
- renaming some titles so it can be used universally on Mac & Windows
